### PR TITLE
feat: add diagnostic and config categories

### DIFF
--- a/custom_components/eufy_security/binary_sensor.py
+++ b/custom_components/eufy_security/binary_sensor.py
@@ -13,6 +13,7 @@ from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_BATTERY_CHARGING,
 )
+from homeassistant.helpers.entity import EntityCategory
 
 from .const import COORDINATOR, DOMAIN, Device
 from .const import get_child_value
@@ -26,60 +27,61 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
     coordinator: EufySecurityDataUpdateCoordinator = hass.data[DOMAIN][COORDINATOR]
 
     INSTRUMENTS = [
-        ("status_led_enabled", "Status Led Enabled", "state.statusLed", "mdi:led-on", None),
+        ("status_led_enabled", "Status Led Enabled", "state.statusLed", "mdi:led-on", None, EntityCategory.DIAGNOSTIC),
 
-        ("motion_sensor", "Motion Sensor", "state.motionDetected", None, DEVICE_CLASS_MOTION),
-        ("motion_detection_enabled", "Motion Detection Enabled", "state.motionDetection", None, DEVICE_CLASS_MOTION),
-        ("person_detector_sensor", "Person Detector Sensor", "state.personDetected", None, DEVICE_CLASS_MOTION),
-        ("person_detection_enabled", "Person Detection Enabled", "state.personDetection", None, DEVICE_CLASS_MOTION),
-        ("pet_detector_sensor", "Pet Detector Sensor", "state.petDetected", None, DEVICE_CLASS_MOTION),
-        ("pet_detection_enabled", "Pet Detection Enabled", "state.petDetection", "mdi: dog", None),
-        ("sound_detector_sensor", "Sound Detector Sensor", "state.soundDetected", None, DEVICE_CLASS_SOUND),
-        ("sound_detection_enabled", "Sound Detection Enabled", "state.soundDetection", "mdi: account-voice", None),
-        ("crying_detector_sensor", "Crying Detector Sensor", "state.cryingDetected", None, DEVICE_CLASS_SOUND),
+        ("motion_sensor", "Motion Sensor", "state.motionDetected", None, DEVICE_CLASS_MOTION, None),
+        ("motion_detection_enabled", "Motion Detection Enabled", "state.motionDetection", None, DEVICE_CLASS_MOTION, EntityCategory.DIAGNOSTIC),
+        ("person_detector_sensor", "Person Detector Sensor", "state.personDetected", None, DEVICE_CLASS_MOTION, EntityCategory.DIAGNOSTIC),
+        ("person_detection_enabled", "Person Detection Enabled", "state.personDetection", None, DEVICE_CLASS_MOTION, EntityCategory.DIAGNOSTIC),
+        ("pet_detector_sensor", "Pet Detector Sensor", "state.petDetected", None, DEVICE_CLASS_MOTION, None),
+        ("pet_detection_enabled", "Pet Detection Enabled", "state.petDetection", "mdi: dog", None, EntityCategory.DIAGNOSTIC),
+        ("sound_detector_sensor", "Sound Detector Sensor", "state.soundDetected", None, DEVICE_CLASS_SOUND, None),
+        ("sound_detection_enabled", "Sound Detection Enabled", "state.soundDetection", "mdi: account-voice", None, EntityCategory.DIAGNOSTIC),
+        ("crying_detector_sensor", "Crying Detector Sensor", "state.cryingDetected", None, DEVICE_CLASS_SOUND, None),
 
-        ("sensor_open", "Sensor Open", "state.sensorOpen", None, DEVICE_CLASS_DOOR),
-        ("battery_low", "Battery Low", "state.batteryLow", None, DEVICE_CLASS_BATTERY),
+        ("sensor_open", "Sensor Open", "state.sensorOpen", None, DEVICE_CLASS_DOOR, None),
+        ("battery_low", "Battery Low", "state.batteryLow", None, DEVICE_CLASS_BATTERY, EntityCategory.DIAGNOSTIC),
 
-        ("ringing_sensor", "Ringing Sensor", "state.ringing", "mdi:bell-ring", None),
+        ("ringing_sensor", "Ringing Sensor", "state.ringing", "mdi:bell-ring", None, None),
 
-        ("motion_tracking_enabled", "Motion Tracking", "state.motionTracking", "mdi:go-kart-track", None),
+        ("motion_tracking_enabled", "Motion Tracking", "state.motionTracking", "mdi:go-kart-track", None, EntityCategory.DIAGNOSTIC),
 
-        ("notification_person_enabled", "Notification for Person", "state.notificationPerson", "mdi:bell-ring", None),
-        ("notification_pet_enabled", "Notification for Pet", "state.notificationPet", "mdi:bell-ring", None),
-        ("notification_all_other_motion_enabled", "Notification for All Other Motion", "state.notificationAllOtherMotion", "mdi:bell-ring", None),
-        ("notification_crying_enabled", "Notification for Crying", "state.notificationCrying", "mdi:bell-ring", None),
-        ("notification_all_sound_enabled", "Notification for All Sound", "state.notificationAllSound", "mdi:bell-ring", None),
+        ("notification_person_enabled", "Notification for Person", "state.notificationPerson", "mdi:bell-ring", None, EntityCategory.DIAGNOSTIC),
+        ("notification_pet_enabled", "Notification for Pet", "state.notificationPet", "mdi:bell-ring", None, EntityCategory.DIAGNOSTIC),
+        ("notification_all_other_motion_enabled", "Notification for All Other Motion", "state.notificationAllOtherMotion", "mdi:bell-ring", None, EntityCategory.DIAGNOSTIC),
+        ("notification_crying_enabled", "Notification for Crying", "state.notificationCrying", "mdi:bell-ring", None, EntityCategory.DIAGNOSTIC),
+        ("notification_all_sound_enabled", "Notification for All Sound", "state.notificationAllSound", "mdi:bell-ring", None, EntityCategory.DIAGNOSTIC),
 
-        ("speaker_enabled", "Speaker", "state.speaker", "mdi:bullhorn", None),
-        ("microphone_enabled", "Microphone", "state.microphone", "mdi:microphone", None),
-        ("auto_night_vision_enabled", "Auto Night vision", "state.autoNightvision", "mdi:weather-night", None),
-        ("audio_recording_enabled", "Audio Recording", "state.audioRecording", "mdi:record-rec", None),
-        ("charging", "Charging Status", "state.chargingStatus", None, DEVICE_CLASS_BATTERY_CHARGING),
+        ("speaker_enabled", "Speaker", "state.speaker", "mdi:bullhorn", None, EntityCategory.DIAGNOSTIC),
+        ("microphone_enabled", "Microphone", "state.microphone", "mdi:microphone", None, EntityCategory.DIAGNOSTIC),
+        ("auto_night_vision_enabled", "Auto Night vision", "state.autoNightvision", "mdi:weather-night", None, EntityCategory.DIAGNOSTIC),
+        ("audio_recording_enabled", "Audio Recording", "state.audioRecording", "mdi:record-rec", None, EntityCategory.DIAGNOSTIC),
+        ("charging", "Charging Status", "state.chargingStatus", None, DEVICE_CLASS_BATTERY_CHARGING, EntityCategory.DIAGNOSTIC),
 
-        ("enabled", "Enabled", "state.enabled", None, DEVICE_CLASS_POWER),
-        ("streaming", "Streaming Sensor", "is_streaming", None, DEVICE_CLASS_MOTION),
-        ("rtsp_stream_enabled", "RTSP Stream", "state.rtspStream", "mdi:cast-connected", None),
+        ("enabled", "Enabled", "state.enabled", None, DEVICE_CLASS_POWER, EntityCategory.DIAGNOSTIC),
+        ("streaming", "Streaming Sensor", "is_streaming", None, DEVICE_CLASS_MOTION, EntityCategory.DIAGNOSTIC),
+        ("rtsp_stream_enabled", "RTSP Stream", "state.rtspStream", "mdi:cast-connected", None, EntityCategory.DIAGNOSTIC),
     ]
 
     entities = []
     for device in coordinator.devices.values():
-        for id, description, key, icon, device_class in INSTRUMENTS:
+        for id, description, key, icon, device_class, entity_category in INSTRUMENTS:
             if not get_child_value(device.__dict__, key) is None:
-                entities.append(EufySecurityBinarySensor(coordinator, config_entry, device, id, description, key, icon, device_class))
+                entities.append(EufySecurityBinarySensor(coordinator, config_entry, device, id, description, key, icon, device_class, entity_category))
 
     async_add_devices(entities, True)
 
 
 class EufySecurityBinarySensor(EufySecurityEntity):
     def __init__(
-        self, coordinator: EufySecurityDataUpdateCoordinator, config_entry: ConfigEntry, device: Device, id: str, description: str, key: str, icon: str, device_class: str):
+        self, coordinator: EufySecurityDataUpdateCoordinator, config_entry: ConfigEntry, device: Device, id: str, description: str, key: str, icon: str, device_class: str, entity_category: str):
         super().__init__(coordinator, config_entry, device)
         self._id = id
         self.description = description
         self.key = key
         self._icon = icon
         self._device_class = device_class
+        self._attr_entity_category = entity_category
 
         if self.id == "motion_sensor" and device.is_motion_sensor() == True:
             self.key = "motionDetection"

--- a/custom_components/eufy_security/select.py
+++ b/custom_components/eufy_security/select.py
@@ -9,6 +9,7 @@ from homeassistant.const import (
     DEVICE_CLASS_SIGNAL_STRENGTH,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 
 from .const import COORDINATOR, DOMAIN, Device
 from. const import get_child_value
@@ -22,26 +23,26 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
     coordinator: EufySecurityDataUpdateCoordinator = hass.data[DOMAIN][COORDINATOR]
 
     INSTRUMENTS = [
-        ("night_vision", "Night Vision", "nightvision"),
-        ("power_working_mode", "Power Working Mode", "powerWorkingMode"),
-        ("video_streaming_quality", "Video Streaming Quality", "videoStreamingQuality"),
-        ("video_recording_quality", "Video Recording Quality", "videoRecordingQuality"),
-        ("motion_detection_type", "Motion Detection Type", "motionDetectionType"),
-        ("rotation_speed", "Rotation Speed", "rotationSpeed"),
+        ("night_vision", "Night Vision", "nightvision", EntityCategory.CONFIG),
+        ("power_working_mode", "Power Working Mode", "powerWorkingMode", EntityCategory.CONFIG),
+        ("video_streaming_quality", "Video Streaming Quality", "videoStreamingQuality", EntityCategory.CONFIG),
+        ("video_recording_quality", "Video Recording Quality", "videoRecordingQuality", EntityCategory.CONFIG),
+        ("motion_detection_type", "Motion Detection Type", "motionDetectionType", EntityCategory.CONFIG),
+        ("rotation_speed", "Rotation Speed", "rotationSpeed", EntityCategory.CONFIG),
     ]
 
     entities = []
     for device in coordinator.devices.values():
         instruments = INSTRUMENTS
-        for id, description, key in instruments:
+        for id, description, key, entity_category in instruments:
             if not get_child_value(device.state, key) is None:
-                entities.append(EufySelectEntity(coordinator, config_entry, device, id, description, key))
+                entities.append(EufySelectEntity(coordinator, config_entry, device, id, description, key, entity_category))
 
     async_add_devices(entities, True)
 
 
 class EufySelectEntity(EufySecurityEntity, SelectEntity):
-    def __init__(self, coordinator: EufySecurityDataUpdateCoordinator, config_entry: ConfigEntry, device: Device, id: str, description: str, key: str):
+    def __init__(self, coordinator: EufySecurityDataUpdateCoordinator, config_entry: ConfigEntry, device: Device, id: str, description: str, key: str, entity_category: str):
         EufySecurityEntity.__init__(self, coordinator, config_entry, device)
         SelectEntity.__init__(self)
         self._id = id
@@ -52,6 +53,7 @@ class EufySelectEntity(EufySecurityEntity, SelectEntity):
         self.values_to_states = self.states.get("states", {})
         self.states_to_values = {v: k for k, v in self.values_to_states.items()}
         self._attr_options: list[str] = list(self.values_to_states.values())
+        self._attr_entity_category = entity_category
 
         _LOGGER.debug(f"{DOMAIN} - {self.device.name} - {self.id} - select init - {self.values_to_states} - {self.states_to_values}")
 

--- a/custom_components/eufy_security/sensor.py
+++ b/custom_components/eufy_security/sensor.py
@@ -10,6 +10,7 @@ from homeassistant.const import (
     DEVICE_CLASS_SIGNAL_STRENGTH,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 
 from .const import COORDINATOR, DOMAIN, Device
 from. const import get_child_value
@@ -23,16 +24,16 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
     coordinator: EufySecurityDataUpdateCoordinator = hass.data[DOMAIN][COORDINATOR]
 
     INSTRUMENTS = [
-        ("battery", "Battery", "state.battery", PERCENTAGE, None, DEVICE_CLASS_BATTERY),
-        ("wifiRSSI", "Wifi RSSI", "state.wifiRSSI", None, None, DEVICE_CLASS_SIGNAL_STRENGTH),
-        ("detected_person_name", "Detected Person Name", "state.personName", None, None, None),
+        ("battery", "Battery", "state.battery", PERCENTAGE, None, DEVICE_CLASS_BATTERY, EntityCategory.DIAGNOSTIC),
+        ("wifiRSSI", "Wifi RSSI", "state.wifiRSSI", None, None, DEVICE_CLASS_SIGNAL_STRENGTH, EntityCategory.DIAGNOSTIC),
+        ("detected_person_name", "Detected Person Name", "state.personName", None, None, None, None),
     ]
 
     CAMERA_INSTRUMENTS = [
-        ("stream_source_type", "Streaming Source Type", "stream_source_type", None, None, None),
-        ("stream_source_address", "Streaming Source Address", "stream_source_address", None, None, None),
-        ("codec", "Codec", "codec", None, None, None),
-        ("stream_queue_size", "Stream Queue Size", "queue", None, None, None),
+        ("stream_source_type", "Streaming Source Type", "stream_source_type", None, None, None, EntityCategory.DIAGNOSTIC),
+        ("stream_source_address", "Streaming Source Address", "stream_source_address", None, None, None, EntityCategory.DIAGNOSTIC),
+        ("codec", "Codec", "codec", None, None, None, EntityCategory.DIAGNOSTIC),
+        ("stream_queue_size", "Stream Queue Size", "queue", None, None, None, EntityCategory.DIAGNOSTIC),
     ]
 
     entities = []
@@ -40,15 +41,15 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
         instruments = INSTRUMENTS
         if device.is_camera() == True:
             instruments = instruments + CAMERA_INSTRUMENTS
-        for id, description, key, unit, icon, device_class in instruments:
+        for id, description, key, unit, icon, device_class, entity_category in instruments:
             if not get_child_value(device.__dict__, key) is None:
-                entities.append(EufySecuritySensor(coordinator, config_entry, device, id, description, key, unit, icon, device_class))
+                entities.append(EufySecuritySensor(coordinator, config_entry, device, id, description, key, unit, icon, device_class, entity_category))
 
     async_add_devices(entities, True)
 
 
 class EufySecuritySensor(EufySecurityEntity):
-    def __init__(self, coordinator: EufySecurityDataUpdateCoordinator, config_entry: ConfigEntry, device: Device, id: str, description: str, key: str, unit: str, icon: str, device_class: str):
+    def __init__(self, coordinator: EufySecurityDataUpdateCoordinator, config_entry: ConfigEntry, device: Device, id: str, description: str, key: str, unit: str, icon: str, device_class: str, entity_category: str):
         super().__init__(coordinator, config_entry, device)
         self._id = id
         self.description = description
@@ -56,6 +57,7 @@ class EufySecuritySensor(EufySecurityEntity):
         self.unit = unit
         self._icon = icon
         self._device_class = device_class
+        self._attr_entity_category = entity_category
 
     @property
     def state(self):

--- a/custom_components/eufy_security/switch.py
+++ b/custom_components/eufy_security/switch.py
@@ -9,6 +9,7 @@ from homeassistant.const import (
     DEVICE_CLASS_SIGNAL_STRENGTH,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 
 from .const import COORDINATOR, DOMAIN, Device
 from. const import get_child_value
@@ -22,36 +23,36 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
     coordinator: EufySecurityDataUpdateCoordinator = hass.data[DOMAIN][COORDINATOR]
 
     INSTRUMENTS = [
-        ("enabled", "Enabled", "enabled"),
-        ("motion_detection", "Motion Detection", "motionDetection"),
-        ("motion_tracking", "Motion Tracking", "motionTracking"),
-        ("person_detection", "Person Detection", "personDetection"),
-        ("pet_detection", "Pet Detection", "petDetection"),
-        ("crying_detection", "Crying Detection", "cryingDetection"),
-        ("indoor_chime", "Indoor Chime", "chimeIndoor"),
-        ("status_led", "Status Led", "statusLed"),
-        ("anti_theft_detection", "Anti Theft Detection", "antitheftDetection"),
-        ("auto_night_vision", "Auto Night Vision", "autoNightvision"),
-        ("night_vision", "Night Vision", "nightvision"),
-        ("microphone", "Microphone", "microphone"),
-        ("speaker", "Speaker", "speaker"),
-        ("audio_recording", "Audio Recording", "audioRecording"),
-        ("light", "Light", "light"),
-        ("rtsp_stream", "RTSP Stream", "rtspStream"),
+        ("enabled", "Enabled", "enabled", EntityCategory.CONFIG),
+        ("motion_detection", "Motion Detection", "motionDetection", EntityCategory.CONFIG),
+        ("motion_tracking", "Motion Tracking", "motionTracking", EntityCategory.CONFIG),
+        ("person_detection", "Person Detection", "personDetection", EntityCategory.CONFIG),
+        ("pet_detection", "Pet Detection", "petDetection", EntityCategory.CONFIG),
+        ("crying_detection", "Crying Detection", "cryingDetection", EntityCategory.CONFIG),
+        ("indoor_chime", "Indoor Chime", "chimeIndoor", EntityCategory.CONFIG),
+        ("status_led", "Status Led", "statusLed", EntityCategory.CONFIG),
+        ("anti_theft_detection", "Anti Theft Detection", "antitheftDetection", EntityCategory.CONFIG),
+        ("auto_night_vision", "Auto Night Vision", "autoNightvision", EntityCategory.CONFIG),
+        ("night_vision", "Night Vision", "nightvision", EntityCategory.CONFIG),
+        ("microphone", "Microphone", "microphone", EntityCategory.CONFIG),
+        ("speaker", "Speaker", "speaker", EntityCategory.CONFIG),
+        ("audio_recording", "Audio Recording", "audioRecording", EntityCategory.CONFIG),
+        ("light", "Light", "light", EntityCategory.CONFIG),
+        ("rtsp_stream", "RTSP Stream", "rtspStream", EntityCategory.CONFIG),
     ]
 
     entities = []
     for device in coordinator.devices.values():
         instruments = INSTRUMENTS
-        for id, description, key in instruments:
+        for id, description, key, entity_category in instruments:
             if not get_child_value(device.state, key) is None:
-                entities.append(EufySwitchEntity(coordinator, config_entry, device, id, description, key, "False", "True"))
+                entities.append(EufySwitchEntity(coordinator, config_entry, device, id, description, key, "False", "True", entity_category))
 
     async_add_devices(entities, True)
 
 
 class EufySwitchEntity(EufySecurityEntity, SwitchEntity):
-    def __init__(self, coordinator: EufySecurityDataUpdateCoordinator, config_entry: ConfigEntry, device: Device, id: str, description: str, key: str, off_value: str, on_value: str):
+    def __init__(self, coordinator: EufySecurityDataUpdateCoordinator, config_entry: ConfigEntry, device: Device, id: str, description: str, key: str, off_value: str, on_value: str, entity_category: str):
         EufySecurityEntity.__init__(self, coordinator, config_entry, device)
         SwitchEntity.__init__(self)
         self._id = id
@@ -59,6 +60,7 @@ class EufySwitchEntity(EufySecurityEntity, SwitchEntity):
         self.key = key
         self.off_value = str(off_value)
         self.on_value = str(on_value)
+        self._attr_entity_category = entity_category
 
     @property
     def is_on(self):


### PR DESCRIPTION
According to https://developers.home-assistant.io/docs/core/entity/ documentation, we can add a `entity_category` to each entity for better display. Diagnostic and config entities are not exposed by google assistant and homekit by default and are not in auto generated lovelace dashboards and room card.

I sorted the sensor myself but you can suggest another sorting if you want 🙂

I also noticed that some binary sensors and duplication of switches. Don't you think we can remove binary sensors that are already listed as switch (can be part of another PR)

![Capture d’écran 2021-12-15 à 14 22 55](https://user-images.githubusercontent.com/5878303/146195704-04ef92f7-765e-45c5-ae6d-a9d9d83c1e3a.png)
![Capture d’écran 2021-12-15 à 14 23 05](https://user-images.githubusercontent.com/5878303/146195708-c3bbab41-f18f-4769-8da7-87ac5e6b9b63.png)
