### PR TITLE
fix: key error in process_driver_connect_response #321

### DIFF
--- a/custom_components/eufy_security/coordinator.py
+++ b/custom_components/eufy_security/coordinator.py
@@ -290,7 +290,7 @@ class EufySecurityDataUpdateCoordinator(DataUpdateCoordinator):
                 return
 
             if message_id == DRIVER_CONNECT_MESSAGE["messageId"]:
-                await self.process_driver_connect_response(message["connected"])
+                await self.process_driver_connect_response(message["result"])
 
             if message_id == SET_CAPTCHA_MESSAGE["messageId"]:
                 self.captcha_config.result = message["result"]


### PR DESCRIPTION
This change will resolve the following error at startup:

```
ERROR (MainThread) [custom_components.eufy_security] eufy_security - Exception - process_messages: 'connected' - traceback: Traceback (most recent call last):
  File "/config/custom_components/eufy_security/websocket.py", line 56, in process_messages
    await self.on_message(msg)
  File "/config/custom_components/eufy_security/websocket.py", line 67, in on_message
    await self.message_callback(message)
  File "/config/custom_components/eufy_security/coordinator.py", line 293, in on_message
    await self.process_driver_connect_response(message["connected"])
KeyError: 'connected'

 - message: WSMessage(type=<WSMsgType.TEXT: 1>, data='{"type":"result","success":true,"messageId":"driver_connect","result":{"result":true}}', extra='')
```
