### PR TITLE
chore: Added Dependabot to update github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  # Enable version updates for Python
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Keeps pesky warnings about deprecated actions at bay.