### PR TITLE
fix: Reloading component when in failed connection state

### DIFF
--- a/custom_components/eufy_security/eufy_security_api/web_socket_client.py
+++ b/custom_components/eufy_security/eufy_security_api/web_socket_client.py
@@ -48,10 +48,12 @@ class WebSocketClient:
 
     async def disconnect(self):
         """Close web socket connection"""
-        await self.socket.close()
-        self.socket = None
-        self.task.cancel()
-        self.task = None
+        if self.socket is not None:
+            await self.socket.close()
+            self.socket = None
+        if self.task is not None:
+            self.task.cancel()
+            self.task = None
 
     async def _on_open(self) -> None:
         if self.open_callback is not None:


### PR DESCRIPTION
When the component is not properly initialised, due to connection problem, the socket is not set so when the component is reloaded will cause it to error and require Home Assistant to be restarted to recover.