### PR TITLE
docs: Clarify use of custom guards from built-in alarm panel 

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,12 +114,14 @@ If you use your own docker service, please run it like this `docker run -it RTSP
 Note: Custom Name 1, Custom Name 2, and Custom Name 3 are labels used to represent the first, second, and third custom guards (modes) you've created in the Eufy Security app. You can trigger your custom guards using the built-in alarm panel card like so:
 
 ```
-arm_custom_bypass -> will trigger your first custom guard defined in Eufy security app (ordered by 'created date')
+arm_custom_bypass -> triggers your first custom guard defined in Eufy security app (ordered by 'created date')
 arm_night -> trigger second custom guard
 arm_vacation -> trigger third custom guard
 ```
 
-These built-in alarm panel services do not correspond with any default Eufy guards, so they are re-purposed to allow further flexibility to trigger custom security modes.  See discussion in #145 for more details.
+For example, you create a "bedtime" mode in Eufy Security app, by default there would be no way to trigger that using the alarm panel card. However, using this integration, you can call the `arm_custom_bypass` service from the alarm panel, which will enable your "bedtime" mode. You can adjust the display name of this mode using Step 8 above.
+
+These built-in alarm panel services do not correspond with any default Eufy guards, so they are re-purposed to allow further flexibility to trigger custom security modes using this integration.  See discussion in #145 for more details.
 
 ![image](https://user-images.githubusercontent.com/11085566/210082270-4de06bbe-0d10-4dde-9fd3-cb12d6758b67.png)
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,17 @@ If you use your own docker service, please run it like this `docker run -it RTSP
 
 7- If you have installed `RTSP Simple Server Add-On`, please put its `IP Address` and `Port` into Integration Configuration page.
 
-8- You can also configure `Cloud Scan Interval`, Video Analyze Duration, `Custom Name 1`, `Custom Name 2` and `Custom Name 3`
+8- You can also configure `Cloud Scan Interval`, Video Analyze Duration, `Custom Name 1`, `Custom Name 2` and `Custom Name 3` 
+
+Note: Custom Name 1, Custom Name 2, and Custom Name 3 are labels used to represent the first, second, and third custom guards (modes) you've created in the Eufy Security app. You can trigger your custom guards using the built-in alarm panel card like so:
+
+```
+arm_custom_bypass -> will trigger your first custom guard defined in Eufy security app (ordered by 'created date')
+arm_night -> trigger second custom guard
+arm_vacation -> trigger third custom guard
+```
+
+These built-in alarm panel services do not correspond with any default Eufy guards, so they are re-purposed to allow further flexibility to trigger custom security modes.  See discussion in #145 for more details.
 
 ![image](https://user-images.githubusercontent.com/11085566/210082270-4de06bbe-0d10-4dde-9fd3-cb12d6758b67.png)
 
@@ -209,7 +219,7 @@ ptz:
   - `arm_home` - Switch to Home state
   - `arm_away` - Switch to Away state
   - `disarm` - Disarm the panel
-  - `alarm_arm_custom1` - Switch to custom 1
+  - `alarm_arm_custom1` - Switch to custom 1, which relates to the first, second, and third custom guards (or modes) you have created in the Eufy Security app. 
   - `alarm_arm_custom2` - Switch to custom 2
   - `alarm_arm_custom3` - Switch to custom 3
   - `geofence` - Switch to geofencing, this might not impact the state of panel given that it will chage its state based on geolocation via eufy app


### PR DESCRIPTION
Spent too much time trying to figure out how to enable user-defined guards. Stumbled across #145 and was able to reverse engineer the associated [commits](https://github.com/fuatakgun/eufy_security/commit/475bcb05184dc9eaa9f1ef6fd86f547d9c4dba1a). 

This functionality should be reflected in the docs. 