### PR TITLE
Don't enable diagnostics by default

### DIFF
--- a/custom_components/eufy_security/entity.py
+++ b/custom_components/eufy_security/entity.py
@@ -1,6 +1,7 @@
 import logging
 
 from homeassistant.helpers import entity_platform
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, PropertyToEntityDescription
@@ -27,6 +28,7 @@ class EufySecurityEntity(CoordinatorEntity):
         self._attr_name = f"{self.product.name} {metadata.label}"
         self._attr_device_class = self.description.device_class
         self._attr_entity_category = self.description.category
+        self._attr_entity_registry_enabled_default = False if self._attr_entity_category == EntityCategory.DIAGNOSTIC else True
 
     @property
     def product(self) -> Product:


### PR DESCRIPTION
This isn't breaking, existing installations will continue to have all diagnostic entities enabled, new installations (and re-installs) will startup have the diagnostic entities disabled, but they can be manually enabled from the device page.