### PR TITLE
fix: for deprecation warnings

### DIFF
--- a/custom_components/eufy_security/__init__.py
+++ b/custom_components/eufy_security/__init__.py
@@ -5,6 +5,7 @@ import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import Config, HomeAssistant
+from homeassistant.components.persistent_notification import create
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.event import async_track_time_interval
@@ -93,7 +94,7 @@ async def async_remove_config_entry_device(hass: HomeAssistant, config_entry: Co
     coordinator = hass.data[DOMAIN][COORDINATOR]
     if serial_no in coordinator.devices or serial_no in coordinator.stations:
         _LOGGER.debug(f"async_remove_config_entry_device error exists {serial_no}")
-        hass.components.persistent_notification.create(f"Device is still accessible on account, cannot be deleted!", title="Eufy Security - Error", notification_id="eufy_security_delete_device_error")
+        create(f"Device is still accessible on account, cannot be deleted!", title="Eufy Security - Error", notification_id="eufy_security_delete_device_error")
         return False
     _LOGGER.debug(f"async_remove_config_entry_device deleted {serial_no}")
     return True

--- a/custom_components/eufy_security/__init__.py
+++ b/custom_components/eufy_security/__init__.py
@@ -94,7 +94,7 @@ async def async_remove_config_entry_device(hass: HomeAssistant, config_entry: Co
     coordinator = hass.data[DOMAIN][COORDINATOR]
     if serial_no in coordinator.devices or serial_no in coordinator.stations:
         _LOGGER.debug(f"async_remove_config_entry_device error exists {serial_no}")
-        create(f"Device is still accessible on account, cannot be deleted!", title="Eufy Security - Error", notification_id="eufy_security_delete_device_error")
+        create(hass, f"Device is still accessible on account, cannot be deleted!", title="Eufy Security - Error", notification_id="eufy_security_delete_device_error")
         return False
     _LOGGER.debug(f"async_remove_config_entry_device deleted {serial_no}")
     return True

--- a/custom_components/eufy_security/__init__.py
+++ b/custom_components/eufy_security/__init__.py
@@ -51,7 +51,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     await coordinator.initialize()
     for platform in PLATFORMS:
         coordinator.platforms.append(platform.value)
-        hass.async_add_job(hass.config_entries.async_forward_entry_setup(config_entry, platform.value))
+        config_entry.async_create_task(hass, hass.config_entries.async_forward_entry_setup(config_entry, platform.value))
 
     async def update(event_time_utc):
         local_coordinator = hass.data[DOMAIN][COORDINATOR]

--- a/custom_components/eufy_security/coordinator.py
+++ b/custom_components/eufy_security/coordinator.py
@@ -103,7 +103,7 @@ class EufySecurityDataUpdateCoordinator(DataUpdateCoordinator):
 
     def _on_error(self, error):
         """raise notification on frontend when exception happens"""
-        create(f"Connection to Eufy Security add-on is broken, retrying in background!", title="Eufy Security - Error", notification_id="eufy_security_addon_connection_error")
+        create(self.hass, f"Connection to Eufy Security add-on is broken, retrying in background!", title="Eufy Security - Error", notification_id="eufy_security_addon_connection_error")
         self.hass.bus.async_listen_once(DISCONNECTED, self._async_reload)
         self.hass.bus.async_fire(DISCONNECTED, None)
 

--- a/custom_components/eufy_security/coordinator.py
+++ b/custom_components/eufy_security/coordinator.py
@@ -6,6 +6,7 @@ import json
 import asyncio
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.components.persistent_notification import create
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -102,7 +103,7 @@ class EufySecurityDataUpdateCoordinator(DataUpdateCoordinator):
 
     def _on_error(self, error):
         """raise notification on frontend when exception happens"""
-        self.hass.components.persistent_notification.create(f"Connection to Eufy Security add-on is broken, retrying in background!", title="Eufy Security - Error", notification_id="eufy_security_addon_connection_error")
+        create(f"Connection to Eufy Security add-on is broken, retrying in background!", title="Eufy Security - Error", notification_id="eufy_security_addon_connection_error")
         self.hass.bus.async_listen_once(DISCONNECTED, self._async_reload)
         self.hass.bus.async_fire(DISCONNECTED, None)
 


### PR DESCRIPTION
This PR fixes deprecations for performance as described [here (hass.components)](https://developers.home-assistant.io/blog/2024/02/27/deprecate-bind-hass-and-hass-components/) #1127 and [here (async_add_job) ](https://developers.home-assistant.io/blog/2024/03/13/deprecate_add_run_job/) #1128