### PR TITLE
fix: Remove deprecated homeassistant.backports.enum

### DIFF
--- a/custom_components/eufy_security/model.py
+++ b/custom_components/eufy_security/model.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
-from enum import Enum, auto
+from enum import auto, Enum, StrEnum
 
-from homeassistant.backports.enum import StrEnum
 from homeassistant.config_entries import ConfigEntry
 
 


### PR DESCRIPTION
https://developers.home-assistant.io/blog/2024/04/08/deprecated-backports-and-typing-aliases/