### PR TITLE
fix: don't use auto() for str enum

### DIFF
--- a/custom_components/eufy_security/alarm_control_panel.py
+++ b/custom_components/eufy_security/alarm_control_panel.py
@@ -46,9 +46,9 @@ class CurrentModeToStateValue(Enum):
     NONE = "Unknown"
     AWAY = AlarmControlPanelState.ARMED_AWAY
     HOME = AlarmControlPanelState.ARMED_HOME
-    CUSTOM_BYPASS = auto()
-    NIGHT = auto()
-    VACATION = auto()
+    CUSTOM_BYPASS = 3
+    NIGHT = 4
+    VACATION = 5
     DISARMED = AlarmControlPanelState.DISARMED
     OFF = STATE_OFF
     TRIGGERED = AlarmControlPanelState.TRIGGERED

--- a/custom_components/eufy_security/model.py
+++ b/custom_components/eufy_security/model.py
@@ -22,16 +22,16 @@ class ConfigField(Enum):
     host = "127.0.0.1"
     port = 3000
     sync_interval = 600  # seconds
-    rtsp_server_address = auto()
+    rtsp_server_address = 3
     no_stream_in_hass = False
     name_for_custom1 = "Custom 1"
     name_for_custom2 = "Custom 2"
     name_for_custom3 = "Custom 3"
-    captcha_id = auto()
-    captcha_img = auto()
-    captcha_input = auto()
-    mfa_required = auto()
-    mfa_input = auto()
+    captcha_id = 8
+    captcha_img = 9
+    captcha_input = 10
+    mfa_required = 11
+    mfa_input = 12
 
 
 @dataclass


### PR DESCRIPTION
Don't use auto() for str enum because it's not supported with HA 2024.12. I quickly solve it by hardcoding the number value but we should have another way to do it.

Fixes https://github.com/fuatakgun/eufy_security/issues/1258