### PR TITLE
feat: Adding Camera Preset Feature

### DIFF
--- a/custom_components/eufy_security/camera.py
+++ b/custom_components/eufy_security/camera.py
@@ -227,6 +227,15 @@ class EufySecurityCamera(Camera, EufySecurityEntity):
     async def _async_ptz_360(self) -> None:
         await self.product.ptz_360()
 
+    async def _async_preset_position(self, position: int) -> None:
+        await self.product.preset_position(position)
+
+    async def _async_save_preset_position(self, position: int) -> None:
+        await self.product.save_preset_position(position)
+
+    async def _async_delete_preset_position(self, position: int) -> None:
+        await self.product.delete_preset_position(position)
+
     async def _async_calibrate(self) -> None:
         await self.product.calibrate()
 

--- a/custom_components/eufy_security/camera.py
+++ b/custom_components/eufy_security/camera.py
@@ -56,6 +56,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
     platform.async_register_entity_service("ptz_left", {}, "_async_ptz_left")
     platform.async_register_entity_service("ptz_right", {}, "_async_ptz_right")
     platform.async_register_entity_service("ptz_360", {}, "_async_ptz_360")
+    platform.async_register_entity_service("preset_position", Schema.PRESET_POSITION_SERVICE_SCHEMA.value, "_async_preset_position")
+    platform.async_register_entity_service("save_preset_position", Schema.PRESET_POSITION_SERVICE_SCHEMA.value, "_async_save_preset_position")
+    platform.async_register_entity_service("delete_preset_position", Schema.PRESET_POSITION_SERVICE_SCHEMA.value, "_async_delete_preset_position")
     platform.async_register_entity_service("calibrate", {}, "_async_calibrate")
 
     platform.async_register_entity_service("trigger_camera_alarm_with_duration", Schema.TRIGGER_ALARM_SERVICE_SCHEMA.value, "_async_alarm_trigger")

--- a/custom_components/eufy_security/const.py
+++ b/custom_components/eufy_security/const.py
@@ -42,6 +42,7 @@ class Schema(Enum):
     """General used service schema definition"""
 
     PTZ_SERVICE_SCHEMA = make_entity_service_schema({vol.Required("direction"): cv.string})
+    PRESET_POSITION_SERVICE_SCHEMA = make_entity_service_schema({vol.Required("position"): cv.Number})
     TRIGGER_ALARM_SERVICE_SCHEMA = make_entity_service_schema({vol.Required("duration"): cv.Number})
     QUICK_RESPONSE_SERVICE_SCHEMA = make_entity_service_schema({vol.Required("voice_id"): cv.Number})
     CHIME_SERVICE_SCHEMA = make_entity_service_schema({vol.Required("ringtone"): cv.Number})

--- a/custom_components/eufy_security/eufy_security_api/api_client.py
+++ b/custom_components/eufy_security/eufy_security_api/api_client.py
@@ -199,6 +199,18 @@ class ApiClient:
         """Process start pan tilt rotate zoom"""
         await self._send_message_get_response(OutgoingMessage(OutgoingMessageType.pan_and_tilt, serial_no=serial_no, direction=direction))
 
+    async def preset_position(self, product_type: ProductType, serial_no: str, position: int) -> None:
+        """Process preset position call"""
+        await self._send_message_get_response(OutgoingMessage(OutgoingMessageType.preset_position, serial_no=serial_no, position=position))
+
+    async def save_preset_position(self, product_type: ProductType, serial_no: str, position: int) -> None:
+        """Process save preset position call"""
+        await self._send_message_get_response(OutgoingMessage(OutgoingMessageType.save_preset_position, serial_no=serial_no, position=position))
+
+    async def delete_preset_position(self, product_type: ProductType, serial_no: str, position: int) -> None:
+        """Process delete preset position call"""
+        await self._send_message_get_response(OutgoingMessage(OutgoingMessageType.delete_preset_position, serial_no=serial_no, position=position))
+
     async def start_rtsp_livestream(self, product_type: ProductType, serial_no: str) -> None:
         """Process start rtsp livestream call"""
         await self._send_message_get_response(OutgoingMessage(OutgoingMessageType.start_rtsp_livestream, serial_no=serial_no))

--- a/custom_components/eufy_security/eufy_security_api/camera.py
+++ b/custom_components/eufy_security/eufy_security_api/camera.py
@@ -204,6 +204,18 @@ class Camera(Device):
         """Look around 360 degrees"""
         await self.api.pan_and_tilt(self.product_type, self.serial_no, PTZCommand.ROTATE360.value)
 
+    async def preset_position(self, position: int) -> None:
+        """Set preset position"""
+        await self.api.preset_position(self.product_type, self.serial_no, position)
+
+    async def save_preset_position(self, position: int) -> None:
+        """Save new preset position"""
+        await self.api.save_preset_position(self.product_type, self.serial_no, position)
+
+    async def delete_preset_position(self, position: int) -> None:
+        """Delete existing preset position"""
+        await self.api.delete_preset_position(self.product_type, self.serial_no, position)
+
     async def calibrate(self) -> None:
         """Calibrate camera"""
         await self.api.calibrate(self.product_type, self.serial_no)

--- a/custom_components/eufy_security/eufy_security_api/const.py
+++ b/custom_components/eufy_security/eufy_security_api/const.py
@@ -6,7 +6,7 @@ from .command_description import CommandDescription
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
-SCHEMA_VERSION = 19
+SCHEMA_VERSION = 21
 
 UNSUPPORTED = "Unsupported"
 
@@ -76,6 +76,7 @@ class MessageField(Enum):
     PICTURE_URL = "pictureUrl"
     PICTURE = "picture"
     DIRECTION = "direction"
+    POSITION = "position"
     LIVE_STREAMING = "livestreaming"
     VOICES = "voices"
     VOICE_ID = "voiceId"

--- a/custom_components/eufy_security/eufy_security_api/outgoing_message.py
+++ b/custom_components/eufy_security/eufy_security_api/outgoing_message.py
@@ -18,6 +18,7 @@ class OutgoingMessageToParameter(Enum):
     captchaId = "captcha_id"
     captcha = "captcha_input"
     direction = "direction"
+    position = "position"
     verifyCode = "verify_code"
     voiceId = "voice_id"
     snoozeTime = "snooze_time"
@@ -65,6 +66,9 @@ class OutgoingMessageType(Enum):
 
     # device level commands
     pan_and_tilt = {MessageField.DUMMY: auto(), MessageField.DOMAIN: EventSourceType.device, MessageField.DIRECTION: None}
+    preset_position = {MessageField.DUMMY: auto(), MessageField.DOMAIN: EventSourceType.device, MessageField.POSITION: None}
+    save_preset_position = {MessageField.DUMMY: auto(), MessageField.DOMAIN: EventSourceType.device, MessageField.POSITION: None}
+    delete_preset_position = {MessageField.DUMMY: auto(), MessageField.DOMAIN: EventSourceType.device, MessageField.POSITION: None}
     calibrate = {MessageField.DUMMY: auto(), MessageField.DOMAIN: EventSourceType.device}
     start_rtsp_livestream = {MessageField.DUMMY: auto(), MessageField.DOMAIN: EventSourceType.device}
     stop_rtsp_livestream = {MessageField.DUMMY: auto(), MessageField.DOMAIN: EventSourceType.device}

--- a/custom_components/eufy_security/services.yaml
+++ b/custom_components/eufy_security/services.yaml
@@ -107,12 +107,9 @@ preset_position:
       required: true
       default: 0
       selector:
-        select:
-          options:
-            - 0
-            - 1
-            - 2
-            - 3
+        number:
+          min: 0
+          max: 3
 
 save_preset_position:
   name: Save preset position
@@ -128,12 +125,9 @@ save_preset_position:
       required: true
       default: 0
       selector:
-        select:
-          options:
-            - 0
-            - 1
-            - 2
-            - 3
+        number:
+          min: 0
+          max: 3
 
 delete_preset_position:
   name: Delete preset position
@@ -149,12 +143,9 @@ delete_preset_position:
       required: true
       default: 0
       selector:
-        select:
-          options:
-            - 0
-            - 1
-            - 2
-            - 3
+        number:
+          min: 0
+          max: 3
 
 calibrate:
   name: Calibrate camera

--- a/custom_components/eufy_security/services.yaml
+++ b/custom_components/eufy_security/services.yaml
@@ -107,9 +107,12 @@ preset_position:
       required: true
       default: 0
       selector:
-        number:
-          min: 0
-          max: 3
+        select:
+          options:
+            - 0
+            - 1
+            - 2
+            - 3
 
 save_preset_position:
   name: Save preset position
@@ -125,9 +128,12 @@ save_preset_position:
       required: true
       default: 0
       selector:
-        number:
-          min: 0
-          max: 3
+        select:
+          options:
+            - 0
+            - 1
+            - 2
+            - 3
 
 delete_preset_position:
   name: Delete preset position
@@ -143,9 +149,12 @@ delete_preset_position:
       required: true
       default: 0
       selector:
-        number:
-          min: 0
-          max: 3
+        select:
+          options:
+            - 0
+            - 1
+            - 2
+            - 3
 
 calibrate:
   name: Calibrate camera

--- a/custom_components/eufy_security/services.yaml
+++ b/custom_components/eufy_security/services.yaml
@@ -105,13 +105,11 @@ preset_position:
       name: Position
       description: Position Option
       required: true
+      default: 0
       selector:
-        select:
-          options:
-            - 0
-            - 1
-            - 2
-            - 3
+        number:
+          min: 0
+          max: 3
 
 save_preset_position:
   name: Save preset position
@@ -125,13 +123,11 @@ save_preset_position:
       name: Position
       description: Position Option
       required: true
+      default: 0
       selector:
-        select:
-          options:
-            - 0
-            - 1
-            - 2
-            - 3
+        number:
+          min: 0
+          max: 3
 
 delete_preset_position:
   name: Delete preset position
@@ -145,13 +141,11 @@ delete_preset_position:
       name: Position
       description: Position Option
       required: true
+      default: 0
       selector:
-        select:
-          options:
-            - 0
-            - 1
-            - 2
-            - 3
+        number:
+          min: 0
+          max: 3
 
 calibrate:
   name: Calibrate camera

--- a/custom_components/eufy_security/services.yaml
+++ b/custom_components/eufy_security/services.yaml
@@ -93,6 +93,66 @@ ptz_left:
       domain: camera
       integration: eufy_security
 
+preset_position:
+  name: Preset position
+  description: Set a preset position for supported cameras
+  target:
+    entity:
+      domain: camera
+      integration: eufy_security
+  fields:
+    position:
+      name: Position
+      description: Position Option
+      required: true
+      selector:
+        select:
+          options:
+            - 0
+            - 1
+            - 2
+            - 3
+
+save_preset_position:
+  name: Save preset position
+  description: Save a new preset position for supported cameras
+  target:
+    entity:
+      domain: camera
+      integration: eufy_security
+  fields:
+    position:
+      name: Position
+      description: Position Option
+      required: true
+      selector:
+        select:
+          options:
+            - 0
+            - 1
+            - 2
+            - 3
+
+delete_preset_position:
+  name: Delete preset position
+  description: Delete an existing preset position for supported cameras
+  target:
+    entity:
+      domain: camera
+      integration: eufy_security
+  fields:
+    position:
+      name: Position
+      description: Position Option
+      required: true
+      selector:
+        select:
+          options:
+            - 0
+            - 1
+            - 2
+            - 3
+
 calibrate:
   name: Calibrate camera
   description: Calibrate supported cameras


### PR DESCRIPTION
The [eufy-security-ws WebSocket](https://github.com/bropat/eufy-security-ws/) implements camera presets (see [here](https://github.com/bropat/eufy-security-ws/blob/0f4850d6dc94ca227f0396364a30c99fa132d863/src/bin/client.ts#L1067)), but they are not exposed in the eufy-security integration yet.

As requested in #1119, I've implemented this feature. Specifically, I've added three new callable services: `preset_position`, `save_preset_position`, `delete_preset_position`. They allow you to set, save, and delete a preset position, respectively.
The Eufy app allows for 4 different presets, which are passed through the `position` argument (values from 0 to 3).

I've tested all features on my Solocam S340 and everything seems to work fine.