### PR TITLE
fix: Go2RTC >=1.9.0 Compatibility (streams: source not supported)

### DIFF
--- a/custom_components/eufy_security/eufy_security_api/p2p_streamer.py
+++ b/custom_components/eufy_security/eufy_security_api/p2p_streamer.py
@@ -73,7 +73,7 @@ class P2PStreamer:
                 result = response.status, await response.text()
                 _LOGGER.debug(f"create_stream_on_go2rtc - delete stream response {result}")
 
-        parameters = {"name": str(self.camera.serial_no), "src": str(self.camera.serial_no)}
+        parameters = {"name": str(self.camera.serial_no), "src": "tcp://127.0.0.1:65535"}
         url = GO2RTC_API_URL.format(self.camera.config.rtsp_server_address, GO2RTC_API_PORT)
         url = f"{url}s"
         async with aiohttp.ClientSession() as session:


### PR DESCRIPTION
Fixes Go2RTC stream configuration for newer versions (`>= 1.9.0`). 

Newer versions of `go2rtc` strictly validate the `src` parameter when registering a stream via `PUT /api/streams`. It rejects arbitary strings (like bare device serial numbers) with a `400 Bad Request: streams: source not supported`, completely breaking the P2P pushed byte ingest pipeline. 

This PR injects a valid placeholder/dummy source schema (`tcp://127.0.0.1:65535`) which successfully bypasses the strict schema validation in `1.9.0+` allowing the stream destination to be configured, while retaining complete backward compatibility with older `go2rtc` versions (which historically did not validate the string anyway).
