### PR TITLE
fix: restore WebRTC P2P audio streaming

### DIFF
--- a/custom_components/eufy_security/eufy_security_api/camera.py
+++ b/custom_components/eufy_security/eufy_security_api/camera.py
@@ -106,8 +106,8 @@ class Camera(Device):
         self.video_queue.append(bytearray(event.data["buffer"]["data"]))
 
     async def _handle_livestream_audio_data_received(self, event: Event):
-        pass
-        #self.audio_queue.append(bytearray(event.data["buffer"]["data"]))
+        #pass
+        self.audio_queue.append(bytearray(event.data["buffer"]["data"]))
 
     async def _initiate_start_stream(self, stream_type) -> bool:
         self.set_stream_provider(stream_type)

--- a/custom_components/eufy_security/eufy_security_api/p2p_streamer.py
+++ b/custom_components/eufy_security/eufy_security_api/p2p_streamer.py
@@ -90,6 +90,6 @@ class P2PStreamer:
         self.retry = None
         await self._create_stream_on_go2rtc()
         await asyncio.gather(
-            #asyncio.to_thread(self._run, self.camera.audio_queue, "audio"),
+            asyncio.to_thread(self._run, self.camera.audio_queue, "audio"),
             asyncio.to_thread(self._run, self.camera.video_queue, "video")
         )


### PR DESCRIPTION
## Summary

This PR restores P2P audio streaming by re-enabling two disabled audio code paths:

- Re-enable audio queue handling in `camera.py`
- Re-enable the audio streaming thread in `p2p_streamer.py`

## Problem

While P2P video streaming worked correctly, WebRTC streams exposed no audio track.

Observed behavior:

- Browser speaker icon was disabled.
- `Audio Queue Size` diagnostic entity confirmed audio packets were being received.
- Audio packets were discarded before reaching the streamer.
- The audio streaming thread was disabled.

## Validation

Verified on:

- 2 × Eufy SoloCam S3 (T8170)
- 1 × Eufy Dual Camera Doorbell E340 (T8214)

Results:

- Live video unchanged
- WebRTC audio track available
- Browser speaker control enabled
- Live audio playback functioning correctly

## Notes

The audio queue functionality was introduced in commit `af7eacf` ("feat: start using deque for faster process with audio").

In commit `0a7ae61` ("feat: update doc and complete p2p streaming"), both the audio queue handler and the audio streaming thread were commented out. This PR re-enables those code paths after validating WebRTC audio functionality on multiple devices.