### PR TITLE
fix: refresh camera still image from latest event picture when not streaming

### DIFF
--- a/custom_components/eufy_security/camera.py
+++ b/custom_components/eufy_security/camera.py
@@ -81,6 +81,7 @@ class EufySecurityCamera(Camera, EufySecurityEntity):
         self._last_image = None
         if self.product.picture_base64 is not None:
             self._last_image = self.product.picture_bytes
+        self._last_picture_updated = self.product.image_last_updated
 
         # ffmpeg entities
         self.ffmpeg = self.coordinator.hass.data[DATA_FFMPEG]
@@ -153,6 +154,11 @@ class EufySecurityCamera(Camera, EufySecurityEntity):
             with contextlib.suppress(asyncio.TimeoutError):
                 self._last_image = await asyncio.wait_for(self._get_image_from_stream_url(width, height), STREAM_TIMEOUT_SECONDS)
             _LOGGER.debug(f"image 2 - is_empty {self._last_image is None}")
+        elif self.product.picture_base64 is not None and self.product.image_last_updated != self._last_picture_updated:
+            # not streaming: pick up a newer event picture (mirrors image.py) instead of
+            # serving whatever picture existed when the entity was created
+            self._last_image = self.product.picture_bytes
+            self._last_picture_updated = self.product.image_last_updated
 
         _LOGGER.debug(f"async_camera_image 5 - is_empty {self._last_image is None}")
         if self._last_image is not None:


### PR DESCRIPTION
## Summary

Fixes #955
Fixes #994

- `EufySecurityCamera.__init__` copies `product.picture_bytes` into `_last_image` once, and `async_camera_image` only refreshes `_last_image` while the camera is streaming.
- When the camera is not streaming, the `camera.*` entity (`/api/camera_proxy`, `entity_picture`, picture-entity cards) keeps serving whatever picture existed when the entity was created. If no picture existed at that moment, `camera_proxy` returns HTTP 500 until the next stream.
- The sibling `image.*_event_image` entity (`image.py`) re-reads `product.picture_bytes` on every call, so it stays fresh while the camera still is frozen — this is the "event image updates, camera thumbnail does not" symptom in both issues.

## Fix

When not streaming, `async_camera_image` now re-reads `product.picture_bytes` — but only when `product.image_last_updated` has changed since the last copy. That keeps the maintainer's intent from #955 (the camera entity holds the last streamed frame) while still picking up a newer event picture instead of the startup one.

The seed in `__init__` is unchanged; the timestamp is recorded there so a picture that existed at creation is not re-copied.

## Test plan

- [x] Unit check against the real `EufySecurityCamera` class inside the HA container (fake product/coordinator): no picture at init → `None`; event picture arrives → its bytes; a stream frame is preserved while the event picture is unchanged; a newer event picture replaces it.
- [x] Same check on unpatched `master`: the event picture never appears (`None` on the second call).
- [x] Installed on a Docker-based Home Assistant 2026.3.3 with integration 8.2.4, restarted HA with all cameras idle: `/api/camera_proxy/<camera>` returns 200 with a JPEG for all three cameras, no `eufy_security` errors in the log.
- [x] `ruff check` reports no new findings (three pre-existing unused imports untouched).

<details>
<summary>Verification script (run with a Home Assistant install on the path; pass the directory that contains <code>custom_components/</code>)</summary>

```python
import asyncio
import datetime
import sys
import types

PKG_ROOT = sys.argv[1] if len(sys.argv) > 1 else "/tmp/eufy_patched"
sys.path.insert(0, PKG_ROOT)

from homeassistant.components.ffmpeg import DATA_FFMPEG  # noqa: E402
from custom_components.eufy_security.camera import EufySecurityCamera  # noqa: E402
from custom_components.eufy_security.eufy_security_api.camera import StreamStatus  # noqa: E402
from custom_components.eufy_security.eufy_security_api.metadata import Metadata  # noqa: E402
from custom_components.eufy_security.eufy_security_api.const import PropertyType  # noqa: E402


class FakeProductType:
    value = "camera"


class FakeProduct:
    """Minimal stand-in for eufy_security_api.product.Camera."""

    def __init__(self):
        self.name = "Test Cam"
        self.serial_no = "T1234567890"
        self.product_type = FakeProductType()
        self.stream_status = StreamStatus.IDLE  # not streaming
        self.stream_debug = {}
        self.picture_base64 = None
        self.image_last_updated = None
        self.is_camera = True

    def set_state_update_listener(self, listener):
        pass

    @property
    def picture_bytes(self):
        return bytearray(self.picture_base64["data"]["data"])


class FakeHass:
    def __init__(self):
        self.data = {DATA_FFMPEG: types.SimpleNamespace(binary="ffmpeg", ffmpeg_stream_content_type="multipart/x-mixed-replace")}


class FakeCoordinator:
    def __init__(self):
        self.hass = FakeHass()
        self.available = True

    def async_update_listeners(self):
        pass


def make_metadata(product):
    return Metadata(
        name="camera",
        label="Camera",
        readable=True,
        writeable=False,
        type=PropertyType.string,
        unit=None,
        min=None,
        max=None,
        product=product,
        command=None,
        states=None,
    )


async def scenario_1_and_2():
    coordinator = FakeCoordinator()
    product = FakeProduct()
    cam = EufySecurityCamera(coordinator, make_metadata(product))

    result1 = await cam.async_camera_image()
    print(f"[{PKG_ROOT}] scenario1 call (no picture yet): {result1!r}")

    t1 = datetime.datetime(2026, 9, 4, 12, 0, 0, tzinfo=datetime.timezone.utc)
    product.picture_base64 = {"data": {"data": list(b"\xff\xd8fakejpeg")}}
    product.image_last_updated = t1

    result2 = await cam.async_camera_image()
    print(f"[{PKG_ROOT}] scenario2 call (event picture arrives, image_last_updated=T1): {result2!r}")

    expected = b"\xff\xd8fakejpeg"
    ok = result1 is None and result2 is not None and bytes(result2) == expected
    print(f"[{PKG_ROOT}] scenario1+2 PASS={ok}")
    return ok


async def scenario_3():
    coordinator = FakeCoordinator()
    product = FakeProduct()
    t1 = datetime.datetime(2026, 9, 4, 12, 0, 0, tzinfo=datetime.timezone.utc)
    product.picture_base64 = {"data": {"data": list(b"initpicture")}}
    product.image_last_updated = t1  # picture already present + timestamped at construction time

    cam = EufySecurityCamera(coordinator, make_metadata(product))
    print(f"[{PKG_ROOT}] scenario3 after init: _last_image={cam._last_image!r} _last_picture_updated={cam._last_picture_updated!r}")

    # simulate a stream frame having just been served (e.g. handle_async_mjpeg_stream / stream path)
    cam._last_image = b"streamframe"

    # not streaming, picture unchanged (still T1) -> the stream frame must be preserved
    result_preserved = await cam.async_camera_image()
    print(f"[{PKG_ROOT}] scenario3 call (picture unchanged, T1): {result_preserved!r}")

    # a newer event picture arrives at T2
    t2 = datetime.datetime(2026, 9, 4, 12, 5, 0, tzinfo=datetime.timezone.utc)
    product.picture_base64 = {"data": {"data": list(b"newerpicture")}}
    product.image_last_updated = t2

    result_new = await cam.async_camera_image()
    print(f"[{PKG_ROOT}] scenario3 call (newer picture, T2): {result_new!r}")

    ok = (
        result_preserved == b"streamframe"
        and result_new is not None
        and bytes(result_new) == b"newerpicture"
    )
    print(f"[{PKG_ROOT}] scenario3 PASS={ok}")
    return ok


async def main():
    ok12 = await scenario_1_and_2()
    ok3 = True
    try:
        ok3 = await scenario_3()
    except AttributeError as e:
        print(f"[{PKG_ROOT}] scenario3 SKIPPED (attribute not present on this file version): {e}")
        ok3 = None
    print(f"[{PKG_ROOT}] OVERALL: scenario1+2={ok12} scenario3={ok3}")


if __name__ == "__main__":
    asyncio.run(main())
```

</details>

The repo has no test suite today, so this is attached rather than committed. Happy to turn it into a pytest test under `tests/` if you would like one.
